### PR TITLE
bump sequels and sqlite3 fixes issue with sqlite3 not building

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "cheerio": "^0.17.0",
     "lodash.flatten": "^2.4.1",
-    "sequelize": "^1.7.9",
-    "sqlite3": "^2.2.7"
+    "sequelize": "^2.0.0",
+    "sqlite3": "^3.0.5"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
nothing major,  fixed building issue for me on yosemite where npm install sqlite3 wouldnt work...
thanks for a very convenient way of getting react-dash docs offline!