### PR TITLE
.on('success') or .success() is no longer supported. Using .then() in…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ var searchIndex = sequelize.define(
   }
 );
 
-searchIndex.sync().success(function() {
+searchIndex.sync().then(function() {
   getData().forEach(function(header) {
     var si = searchIndex.build({
       name: header.name,


### PR DESCRIPTION
According to the [changelog 2.1.0](http://sequelize.readthedocs.org/en/latest/changelog/index.html)

<blockquote>Events support have been removed so using .on('success') or .success() is no longer supported. Try using .then() instead.</blockquote>
